### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -4,6 +4,8 @@
 # SETTINGS_FILE
 # PAT
 name: Run Docker build of Village Crawler
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/vinaghost/TravianMapSqlCrawler/security/code-scanning/2](https://github.com/vinaghost/TravianMapSqlCrawler/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to restrict the `GITHUB_TOKEN` permissions. Based on the workflow's operations, it only needs to read repository contents to download the settings file. Therefore, we will set `contents: read` as the minimal required permission. This change will ensure that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
