### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@
 # DOCKERHUB_TOKEN
 
 name: Build and push Village Crawler image
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/vinaghost/TravianMapSqlCrawler/security/code-scanning/1](https://github.com/vinaghost/TravianMapSqlCrawler/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow to explicitly define the permissions for the `GITHUB_TOKEN`. Since the workflow does not appear to require any write permissions to the repository, the minimal permissions of `contents: read` should suffice. This ensures that the workflow operates with the least privilege necessary.

The `permissions` block should be added immediately after the `name` field in the workflow file. This will apply the permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
